### PR TITLE
Corrected links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ This repo is meant to provide some examples for Kibana Canvas workpads. Simply d
 #### [Sample Data: Flight Console](https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/sample_data/flight_data)
 ![screenshot](https://github.com/alexfrancoeur/kibana_canvas_examples/blob/master/images/flight_data.png)
 
-#### [Sample Data: Operational Monitoring](https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/sample_data/flight_data)
+#### [Sample Data: Operational Monitoring](https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/sample_data/web_logs)
 ![screenshot](https://github.com/alexfrancoeur/kibana_canvas_examples/blob/master/images/web_logs.png)
 
-#### [Public Data: Boston Energy and Water Metrics](https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/public_data_sets/boston)
+#### [Public Data: Boston Energy and Water Metrics](https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/public_data_sets/boston_energy_water_metrics_2017)
 ![screenshot](https://github.com/alexfrancoeur/kibana_canvas_examples/blob/master/images/boston_workpad.png)


### PR DESCRIPTION
Correct link to the Web Logs (Operational Monitoring) demo:
https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/sample_data/web_logs

Correct link for Boston public data repo: https://github.com/alexfrancoeur/kibana_canvas_examples/tree/master/public_data_sets/boston_energy_water_metrics_2017