### PR TITLE
Feat: Dockerize stats index

### DIFF
--- a/presentations/elasticon2018/scripts/Dockerfile
+++ b/presentations/elasticon2018/scripts/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3-alpine
+
+WORKDIR /app
+ADD canvas_intro_stats.py ./
+
+RUN pip install elasticsearch pytz
+
+CMD [ "python", "./canvas_intro_stats.py" ]

--- a/presentations/elasticon2018/scripts/README.md
+++ b/presentations/elasticon2018/scripts/README.md
@@ -1,0 +1,11 @@
+# scripts
+
+### canvas_intro_stats.py
+
+Indexes fake stats data to `canvas_stats`. Requires python3 and the `elasticsearch` and `pytz` modules.
+
+You can use the included Dockerfile to make this easier:
+
+- Edit the `canvas_intro_stats.py` to point at your local cluster
+- Build the docker image: `docker build -t elasticon2018-stats-index .`
+- Run the docker image: `docker run elasticon2018-stats-index`


### PR DESCRIPTION
Adds a Dockerfile and README to the elasticon2018 scripts. This makes it a lot easier to run the indexing script, since it takes care of the python runtime and required pip modules.